### PR TITLE
Track burst counts in pipeline

### DIFF
--- a/DRAFTS/alma/config.py
+++ b/DRAFTS/alma/config.py
@@ -5,10 +5,16 @@ from pathlib import Path
 from typing import Optional
 
 import numpy as np
-import torch
+try:
+    import torch
+except ImportError:  # pragma: no cover - optional dependency
+    torch = None
 
 # Device configuration ---------------------------------------------------------
-DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+if torch is not None:
+    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+else:
+    DEVICE = "cpu"
 
 # Observation parameters -------------------------------------------------------
 FREQ: np.ndarray | None = None

--- a/DRAFTS/config.py
+++ b/DRAFTS/config.py
@@ -5,10 +5,16 @@ from pathlib import Path
 from typing import Optional
 
 import numpy as np
-import torch
+try:
+    import torch
+except ImportError:  # pragma: no cover - optional dependency
+    torch = None
 
 # Configuracion del dispositivo ---------------------------------------------------
-DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu") # Uso de GPU si está disponible, de lo contrario usa CPU.
+if torch is not None:
+    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+else:
+    DEVICE = "cpu"
 
 # Parametros de observacion -------------------------------------------------------
 FREQ: np.ndarray | None = None # Frecuencia de observación, puede ser None si no se especifica.


### PR DESCRIPTION
## Summary
- make dependency imports optional for tests
- count bursts and non-bursts in `_process_file`
- document new summary fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685864ebea1483228de9a63dbebc7b63