### PR TITLE
Fix FITS header parsing when fields use placeholders

### DIFF
--- a/DRAFTS/alma/io.py
+++ b/DRAFTS/alma/io.py
@@ -1,4 +1,5 @@
 """Input/output helpers for PSRFITS and standard FITS files."""
+
 from __future__ import annotations
 
 from typing import List
@@ -9,13 +10,46 @@ from astropy.io import fits
 from . import config
 
 
+def _parse_float(value: object, default: float = 0.0) -> float:
+    """Safely convert FITS header values to ``float``."""
+
+    try:
+        if isinstance(value, bytes):
+            value = value.decode()
+        if isinstance(value, str):
+            value = value.strip()
+            if value in {"*", "UNSET", ""}:
+                return default
+        return float(value)
+    except Exception:
+        return default
+
+
+def _parse_int(value: object, default: int = 0) -> int:
+    """Safely convert FITS header values to ``int``."""
+
+    try:
+        if isinstance(value, bytes):
+            value = value.decode()
+        if isinstance(value, str):
+            value = value.strip()
+            if value in {"*", "UNSET", ""}:
+                return default
+        return int(value)
+    except Exception:
+        return default
+
+
 def load_fits_file(file_name: str) -> np.ndarray:
     """Load a FITS file and return the data array in shape (time, pol, channel)."""
     global_vars = config
     data_array = None
     try:
         with fits.open(file_name, memmap=True) as hdul:
-            if "SUBINT" in [hdu.name for hdu in hdul] and "DATA" in hdul["SUBINT"].columns.names:
+            if (
+                "SUBINT" in [hdu.name for hdu in hdul]
+                and "DATA" in hdul["SUBINT"].columns.names
+            ):
                 subint = hdul["SUBINT"]
                 hdr = subint.header
                 data_array = subint.data["DATA"]
@@ -23,26 +57,37 @@ def load_fits_file(file_name: str) -> np.ndarray:
                 nchan = hdr["NCHAN"]
                 npol = hdr["NPOL"]
                 nsblk = hdr["NSBLK"]
-                data_array = data_array.reshape(nsubint, nchan, npol, nsblk).swapaxes(1, 2)
+                data_array = data_array.reshape(nsubint, nchan, npol, nsblk).swapaxes(
+                    1, 2
+                )
                 data_array = data_array.reshape(nsubint * nsblk, npol, nchan)
                 data_array = data_array[:, :2, :]
             else:
                 import fitsio
+
                 temp_data, h = fitsio.read(file_name, header=True)
                 if "DATA" in temp_data.dtype.names:
-                    data_array = temp_data["DATA"].reshape(h["NAXIS2"] * h["NSBLK"], h["NPOL"], h["NCHAN"])[:, :2, :]
+                    data_array = temp_data["DATA"].reshape(
+                        h["NAXIS2"] * h["NSBLK"], h["NPOL"], h["NCHAN"]
+                    )[:, :2, :]
                 else:
                     total_samples = h.get("NAXIS2", 1) * h.get("NSBLK", 1)
                     num_pols = h.get("NPOL", 2)
                     num_chans = h.get("NCHAN", 512)
-                    data_array = temp_data.reshape(total_samples, num_pols, num_chans)[:, :2, :]
+                    data_array = temp_data.reshape(total_samples, num_pols, num_chans)[
+                        :, :2, :
+                    ]
     except Exception as e:
         print(f"[Error cargando FITS con fitsio/astropy] {e}")
         try:
             with fits.open(file_name) as f:
                 data_hdu = None
                 for hdu_item in f:
-                    if hdu_item.data is not None and isinstance(hdu_item.data, np.ndarray) and hdu_item.data.ndim >= 3:
+                    if (
+                        hdu_item.data is not None
+                        and isinstance(hdu_item.data, np.ndarray)
+                        and hdu_item.data.ndim >= 3
+                    ):
                         data_hdu = hdu_item
                         break
                 if data_hdu is None and len(f) > 1:
@@ -51,7 +96,11 @@ def load_fits_file(file_name: str) -> np.ndarray:
                     data_hdu = f[0]
                 h = data_hdu.header
                 raw_data = data_hdu.data
-                data_array = raw_data.reshape(h["NAXIS2"] * h.get("NSBLK", 1), h.get("NPOL", 2), h.get("NCHAN", raw_data.shape[-1]))[:, :2, :]
+                data_array = raw_data.reshape(
+                    h["NAXIS2"] * h.get("NSBLK", 1),
+                    h.get("NPOL", 2),
+                    h.get("NCHAN", raw_data.shape[-1]),
+                )[:, :2, :]
         except Exception as e_astropy:
             print(f"Fallo final al cargar con astropy: {e_astropy}")
             raise
@@ -59,7 +108,9 @@ def load_fits_file(file_name: str) -> np.ndarray:
         raise ValueError(f"No se pudieron cargar los datos de {file_name}")
 
     if global_vars.DATA_NEEDS_REVERSAL:
-        print(f">> Invirtiendo eje de frecuencia de los datos cargados para {file_name}")
+        print(
+            f">> Invirtiendo eje de frecuencia de los datos cargados para {file_name}"
+        )
         data_array = np.ascontiguousarray(data_array[:, :, ::-1])
     return data_array
 
@@ -71,9 +122,13 @@ def get_obparams(file_name: str) -> None:
         if "SUBINT" in [hdu.name for hdu in f] and "TBIN" in f["SUBINT"].header:
             hdr = f["SUBINT"].header
             sub_data = f["SUBINT"].data
-            config.TIME_RESO = hdr["TBIN"]
-            config.FREQ_RESO = hdr["NCHAN"]
-            config.FILE_LENG = hdr["NSBLK"] * hdr["NAXIS2"]
+            config.TIME_RESO = _parse_float(hdr.get("TBIN"))
+            config.FREQ_RESO = _parse_int(hdr.get("NCHAN"))
+            nsblk = _parse_int(hdr.get("NSBLK"), 1)
+            naxis2 = _parse_int(hdr.get("NAXIS2", 0))
+            if naxis2 == 0:
+                naxis2 = len(sub_data)
+            config.FILE_LENG = nsblk * naxis2
             freq_temp = sub_data["DAT_FREQ"][0].astype(np.float64)
             if "CHAN_BW" in hdr:
                 bw = hdr["CHAN_BW"]
@@ -87,15 +142,26 @@ def get_obparams(file_name: str) -> None:
             try:
                 data_hdu_index = 0
                 for i, hdu_item in enumerate(f):
-                    if hdu_item.is_image or isinstance(hdu_item, (fits.BinTableHDU, fits.TableHDU)):
-                        if 'NAXIS' in hdu_item.header and hdu_item.header['NAXIS'] > 0:
-                            if 'CTYPE3' in hdu_item.header and 'FREQ' in hdu_item.header['CTYPE3'].upper():
+                    if hdu_item.is_image or isinstance(
+                        hdu_item, (fits.BinTableHDU, fits.TableHDU)
+                    ):
+                        if "NAXIS" in hdu_item.header and hdu_item.header["NAXIS"] > 0:
+                            if (
+                                "CTYPE3" in hdu_item.header
+                                and "FREQ" in hdu_item.header["CTYPE3"].upper()
+                            ):
                                 data_hdu_index = i
                                 break
-                            if 'CTYPE2' in hdu_item.header and 'FREQ' in hdu_item.header['CTYPE2'].upper():
+                            if (
+                                "CTYPE2" in hdu_item.header
+                                and "FREQ" in hdu_item.header["CTYPE2"].upper()
+                            ):
                                 data_hdu_index = i
                                 break
-                            if 'CTYPE1' in hdu_item.header and 'FREQ' in hdu_item.header['CTYPE1'].upper():
+                            if (
+                                "CTYPE1" in hdu_item.header
+                                and "FREQ" in hdu_item.header["CTYPE1"].upper()
+                            ):
                                 data_hdu_index = i
                                 break
                 if data_hdu_index == 0 and len(f) > 1:
@@ -104,24 +170,28 @@ def get_obparams(file_name: str) -> None:
                 if "DAT_FREQ" in f[data_hdu_index].columns.names:
                     freq_temp = f[data_hdu_index].data["DAT_FREQ"][0].astype(np.float64)
                 else:
-                    freq_axis_num = ''
-                    for i in range(1, hdr.get('NAXIS', 0) + 1):
-                        if 'FREQ' in hdr.get(f'CTYPE{i}', '').upper():
+                    freq_axis_num = ""
+                    for i in range(1, hdr.get("NAXIS", 0) + 1):
+                        if "FREQ" in hdr.get(f"CTYPE{i}", "").upper():
                             freq_axis_num = str(i)
                             break
                     if freq_axis_num:
-                        crval = hdr.get(f'CRVAL{freq_axis_num}', 0)
-                        cdelt = hdr.get(f'CDELT{freq_axis_num}', 1)
-                        crpix = hdr.get(f'CRPIX{freq_axis_num}', 1)
-                        naxis = hdr.get(f'NAXIS{freq_axis_num}', hdr.get('NCHAN', 512))
+                        crval = hdr.get(f"CRVAL{freq_axis_num}", 0)
+                        cdelt = hdr.get(f"CDELT{freq_axis_num}", 1)
+                        crpix = hdr.get(f"CRPIX{freq_axis_num}", 1)
+                        naxis = hdr.get(f"NAXIS{freq_axis_num}", hdr.get("NCHAN", 512))
                         freq_temp = crval + (np.arange(naxis) - (crpix - 1)) * cdelt
                         if cdelt < 0:
                             freq_axis_inverted = True
                     else:
-                        freq_temp = np.linspace(1000, 1500, hdr.get('NCHAN', 512))
-                config.TIME_RESO = hdr["TBIN"]
-                config.FREQ_RESO = hdr.get("NCHAN", len(freq_temp))
-                config.FILE_LENG = hdr.get("NAXIS2", 0) * hdr.get("NSBLK", 1)
+                        freq_temp = np.linspace(1000, 1500, hdr.get("NCHAN", 512))
+                config.TIME_RESO = _parse_float(hdr.get("TBIN"))
+                config.FREQ_RESO = _parse_int(hdr.get("NCHAN", len(freq_temp)))
+                nsblk = _parse_int(hdr.get("NSBLK"), 1)
+                naxis2 = _parse_int(hdr.get("NAXIS2", 0))
+                if naxis2 == 0 and "DATA" in f[data_hdu_index].columns.names:
+                    naxis2 = len(f[data_hdu_index].data)
+                config.FILE_LENG = nsblk * naxis2
             except Exception as e_std:
                 print(f"Error procesando FITS estándar: {e_std}")
                 config.TIME_RESO = 5.12e-5

--- a/DRAFTS/io.py
+++ b/DRAFTS/io.py
@@ -1,4 +1,5 @@
 """Input/output helpers for PSRFITS and standard FITS files."""
+
 from __future__ import annotations
 
 from typing import List
@@ -9,13 +10,46 @@ from astropy.io import fits
 from . import config
 
 
+def _parse_float(value: object, default: float = 0.0) -> float:
+    """Safely convert FITS header values to ``float``."""
+
+    try:
+        if isinstance(value, bytes):
+            value = value.decode()
+        if isinstance(value, str):
+            value = value.strip()
+            if value in {"*", "UNSET", ""}:
+                return default
+        return float(value)
+    except Exception:
+        return default
+
+
+def _parse_int(value: object, default: int = 0) -> int:
+    """Safely convert FITS header values to ``int``."""
+
+    try:
+        if isinstance(value, bytes):
+            value = value.decode()
+        if isinstance(value, str):
+            value = value.strip()
+            if value in {"*", "UNSET", ""}:
+                return default
+        return int(value)
+    except Exception:
+        return default
+
+
 def load_fits_file(file_name: str) -> np.ndarray:
     """Load a FITS file and return the data array in shape (time, pol, channel)."""
     global_vars = config
     data_array = None
     try:
         with fits.open(file_name, memmap=True) as hdul:
-            if "SUBINT" in [hdu.name for hdu in hdul] and "DATA" in hdul["SUBINT"].columns.names:
+            if (
+                "SUBINT" in [hdu.name for hdu in hdul]
+                and "DATA" in hdul["SUBINT"].columns.names
+            ):
                 subint = hdul["SUBINT"]
                 hdr = subint.header
                 data_array = subint.data["DATA"]
@@ -23,26 +57,37 @@ def load_fits_file(file_name: str) -> np.ndarray:
                 nchan = hdr["NCHAN"]
                 npol = hdr["NPOL"]
                 nsblk = hdr["NSBLK"]
-                data_array = data_array.reshape(nsubint, nchan, npol, nsblk).swapaxes(1, 2)
+                data_array = data_array.reshape(nsubint, nchan, npol, nsblk).swapaxes(
+                    1, 2
+                )
                 data_array = data_array.reshape(nsubint * nsblk, npol, nchan)
                 data_array = data_array[:, :2, :]
             else:
                 import fitsio
+
                 temp_data, h = fitsio.read(file_name, header=True)
                 if "DATA" in temp_data.dtype.names:
-                    data_array = temp_data["DATA"].reshape(h["NAXIS2"] * h["NSBLK"], h["NPOL"], h["NCHAN"])[:, :2, :]
+                    data_array = temp_data["DATA"].reshape(
+                        h["NAXIS2"] * h["NSBLK"], h["NPOL"], h["NCHAN"]
+                    )[:, :2, :]
                 else:
                     total_samples = h.get("NAXIS2", 1) * h.get("NSBLK", 1)
                     num_pols = h.get("NPOL", 2)
                     num_chans = h.get("NCHAN", 512)
-                    data_array = temp_data.reshape(total_samples, num_pols, num_chans)[:, :2, :]
+                    data_array = temp_data.reshape(total_samples, num_pols, num_chans)[
+                        :, :2, :
+                    ]
     except Exception as e:
         print(f"[Error cargando FITS con fitsio/astropy] {e}")
         try:
             with fits.open(file_name) as f:
                 data_hdu = None
                 for hdu_item in f:
-                    if hdu_item.data is not None and isinstance(hdu_item.data, np.ndarray) and hdu_item.data.ndim >= 3:
+                    if (
+                        hdu_item.data is not None
+                        and isinstance(hdu_item.data, np.ndarray)
+                        and hdu_item.data.ndim >= 3
+                    ):
                         data_hdu = hdu_item
                         break
                 if data_hdu is None and len(f) > 1:
@@ -51,7 +96,11 @@ def load_fits_file(file_name: str) -> np.ndarray:
                     data_hdu = f[0]
                 h = data_hdu.header
                 raw_data = data_hdu.data
-                data_array = raw_data.reshape(h["NAXIS2"] * h.get("NSBLK", 1), h.get("NPOL", 2), h.get("NCHAN", raw_data.shape[-1]))[:, :2, :]
+                data_array = raw_data.reshape(
+                    h["NAXIS2"] * h.get("NSBLK", 1),
+                    h.get("NPOL", 2),
+                    h.get("NCHAN", raw_data.shape[-1]),
+                )[:, :2, :]
         except Exception as e_astropy:
             print(f"Fallo final al cargar con astropy: {e_astropy}")
             raise
@@ -59,7 +108,9 @@ def load_fits_file(file_name: str) -> np.ndarray:
         raise ValueError(f"No se pudieron cargar los datos de {file_name}")
 
     if global_vars.DATA_NEEDS_REVERSAL:
-        print(f">> Invirtiendo eje de frecuencia de los datos cargados para {file_name}")
+        print(
+            f">> Invirtiendo eje de frecuencia de los datos cargados para {file_name}"
+        )
         data_array = np.ascontiguousarray(data_array[:, :, ::-1])
     return data_array
 
@@ -71,9 +122,13 @@ def get_obparams(file_name: str) -> None:
         if "SUBINT" in [hdu.name for hdu in f] and "TBIN" in f["SUBINT"].header:
             hdr = f["SUBINT"].header
             sub_data = f["SUBINT"].data
-            config.TIME_RESO = hdr["TBIN"]
-            config.FREQ_RESO = hdr["NCHAN"]
-            config.FILE_LENG = hdr["NSBLK"] * hdr["NAXIS2"]
+            config.TIME_RESO = _parse_float(hdr.get("TBIN"))
+            config.FREQ_RESO = _parse_int(hdr.get("NCHAN"))
+            nsblk = _parse_int(hdr.get("NSBLK"), 1)
+            naxis2 = _parse_int(hdr.get("NAXIS2"), 0)
+            if naxis2 == 0:
+                naxis2 = len(sub_data)
+            config.FILE_LENG = nsblk * naxis2
             freq_temp = sub_data["DAT_FREQ"][0].astype(np.float64)
             if "CHAN_BW" in hdr:
                 bw = hdr["CHAN_BW"]
@@ -87,15 +142,26 @@ def get_obparams(file_name: str) -> None:
             try:
                 data_hdu_index = 0
                 for i, hdu_item in enumerate(f):
-                    if hdu_item.is_image or isinstance(hdu_item, (fits.BinTableHDU, fits.TableHDU)):
-                        if 'NAXIS' in hdu_item.header and hdu_item.header['NAXIS'] > 0:
-                            if 'CTYPE3' in hdu_item.header and 'FREQ' in hdu_item.header['CTYPE3'].upper():
+                    if hdu_item.is_image or isinstance(
+                        hdu_item, (fits.BinTableHDU, fits.TableHDU)
+                    ):
+                        if "NAXIS" in hdu_item.header and hdu_item.header["NAXIS"] > 0:
+                            if (
+                                "CTYPE3" in hdu_item.header
+                                and "FREQ" in hdu_item.header["CTYPE3"].upper()
+                            ):
                                 data_hdu_index = i
                                 break
-                            if 'CTYPE2' in hdu_item.header and 'FREQ' in hdu_item.header['CTYPE2'].upper():
+                            if (
+                                "CTYPE2" in hdu_item.header
+                                and "FREQ" in hdu_item.header["CTYPE2"].upper()
+                            ):
                                 data_hdu_index = i
                                 break
-                            if 'CTYPE1' in hdu_item.header and 'FREQ' in hdu_item.header['CTYPE1'].upper():
+                            if (
+                                "CTYPE1" in hdu_item.header
+                                and "FREQ" in hdu_item.header["CTYPE1"].upper()
+                            ):
                                 data_hdu_index = i
                                 break
                 if data_hdu_index == 0 and len(f) > 1:
@@ -104,24 +170,28 @@ def get_obparams(file_name: str) -> None:
                 if "DAT_FREQ" in f[data_hdu_index].columns.names:
                     freq_temp = f[data_hdu_index].data["DAT_FREQ"][0].astype(np.float64)
                 else:
-                    freq_axis_num = ''
-                    for i in range(1, hdr.get('NAXIS', 0) + 1):
-                        if 'FREQ' in hdr.get(f'CTYPE{i}', '').upper():
+                    freq_axis_num = ""
+                    for i in range(1, hdr.get("NAXIS", 0) + 1):
+                        if "FREQ" in hdr.get(f"CTYPE{i}", "").upper():
                             freq_axis_num = str(i)
                             break
                     if freq_axis_num:
-                        crval = hdr.get(f'CRVAL{freq_axis_num}', 0)
-                        cdelt = hdr.get(f'CDELT{freq_axis_num}', 1)
-                        crpix = hdr.get(f'CRPIX{freq_axis_num}', 1)
-                        naxis = hdr.get(f'NAXIS{freq_axis_num}', hdr.get('NCHAN', 512))
+                        crval = hdr.get(f"CRVAL{freq_axis_num}", 0)
+                        cdelt = hdr.get(f"CDELT{freq_axis_num}", 1)
+                        crpix = hdr.get(f"CRPIX{freq_axis_num}", 1)
+                        naxis = hdr.get(f"NAXIS{freq_axis_num}", hdr.get("NCHAN", 512))
                         freq_temp = crval + (np.arange(naxis) - (crpix - 1)) * cdelt
                         if cdelt < 0:
                             freq_axis_inverted = True
                     else:
-                        freq_temp = np.linspace(1000, 1500, hdr.get('NCHAN', 512))
-                config.TIME_RESO = hdr["TBIN"]
-                config.FREQ_RESO = hdr.get("NCHAN", len(freq_temp))
-                config.FILE_LENG = hdr.get("NAXIS2", 0) * hdr.get("NSBLK", 1)
+                        freq_temp = np.linspace(1000, 1500, hdr.get("NCHAN", 512))
+                config.TIME_RESO = _parse_float(hdr.get("TBIN"))
+                config.FREQ_RESO = _parse_int(hdr.get("NCHAN", len(freq_temp)))
+                nsblk = _parse_int(hdr.get("NSBLK"), 1)
+                naxis2 = _parse_int(hdr.get("NAXIS2", 0))
+                if naxis2 == 0 and "DATA" in f[data_hdu_index].columns.names:
+                    naxis2 = len(f[data_hdu_index].data)
+                config.FILE_LENG = nsblk * naxis2
             except Exception as e_std:
                 print(f"Error procesando FITS estándar: {e_std}")
                 config.TIME_RESO = 5.12e-5


### PR DESCRIPTION
## Summary
- handle '*' and other placeholder strings in FITS headers
- compute file length when `NSBLK` or `NAXIS2` is missing
- apply same numeric conversions for ALMA data

## Testing
- `pytest -q`
