### PR TITLE
Add filterbank support to pipeline

### DIFF
--- a/DRAFTS/filterbank_io.py
+++ b/DRAFTS/filterbank_io.py
@@ -1,0 +1,142 @@
+"""Helper functions to read SIGPROC filterbank (.fil) files."""
+from __future__ import annotations
+
+import os
+import struct
+from pathlib import Path
+from typing import Tuple
+
+import numpy as np
+
+from . import config
+
+
+def _read_int(f) -> int:
+    return struct.unpack("<i", f.read(4))[0]
+
+
+def _read_double(f) -> float:
+    return struct.unpack("<d", f.read(8))[0]
+
+
+def _read_string(f) -> str:
+    length = _read_int(f)
+    return f.read(length).decode()
+
+
+def _read_header(f) -> Tuple[dict, int]:
+    start = _read_string(f)
+    if start != "HEADER_START":
+        raise ValueError("Invalid filterbank file")
+
+    header = {}
+    while True:
+        key = _read_string(f)
+        if key == "HEADER_END":
+            break
+        if key in {"rawdatafile", "source_name"}:
+            header[key] = _read_string(f)
+        elif key in {
+            "telescope_id",
+            "machine_id",
+            "data_type",
+            "barycentric",
+            "pulsarcentric",
+            "nbits",
+            "nchans",
+            "nifs",
+            "nbeams",
+            "ibeam",
+            "nsamples",
+        }:
+            header[key] = _read_int(f)
+        elif key in {
+            "az_start",
+            "za_start",
+            "src_raj",
+            "src_dej",
+            "tstart",
+            "tsamp",
+            "fch1",
+            "foff",
+            "refdm",
+        }:
+            header[key] = _read_double(f)
+        else:
+            # Read unknown field as integer by default
+            header[key] = _read_int(f)
+    return header, f.tell()
+
+
+def load_fil_file(file_name: str) -> np.ndarray:
+    """Load a filterbank file and return data as ``(time, pol, channel)``."""
+    with open(file_name, "rb") as f:
+        header, hdr_len = _read_header(f)
+
+    nchans = header.get("nchans", 0)
+    nifs = header.get("nifs", 1)
+    nbits = header.get("nbits", 8)
+    nsamples = header.get("nsamples")
+    if nsamples is None:
+        bytes_per_sample = nifs * nchans * (nbits // 8)
+        file_size = os.path.getsize(file_name) - hdr_len
+        nsamples = file_size // bytes_per_sample
+
+    dtype = np.uint8
+    if nbits == 16:
+        dtype = np.int16
+    elif nbits == 32:
+        dtype = np.float32
+    elif nbits == 64:
+        dtype = np.float64
+
+    data = np.memmap(file_name, dtype=dtype, mode="r", offset=hdr_len,
+                     shape=(nsamples, nifs, nchans))
+    data = np.asarray(data, dtype=np.float32)
+    if data.shape[1] == 1:
+        data = np.repeat(data, 2, axis=1)
+    else:
+        data = data[:, :2, :]
+
+    if config.DATA_NEEDS_REVERSAL:
+        data = np.ascontiguousarray(data[:, :, ::-1])
+    return data
+
+
+def get_obparams_fil(file_name: str) -> None:
+    """Populate :mod:`config` using parameters from a filterbank file."""
+    with open(file_name, "rb") as f:
+        header, hdr_len = _read_header(f)
+
+    nchans = header.get("nchans", 0)
+    tsamp = header.get("tsamp", 0.0)
+    nifs = header.get("nifs", 1)
+    nbits = header.get("nbits", 8)
+    nsamples = header.get("nsamples")
+    if nsamples is None:
+        bytes_per_sample = nifs * nchans * (nbits // 8)
+        file_size = os.path.getsize(file_name) - hdr_len
+        nsamples = file_size // bytes_per_sample
+
+    fch1 = header.get("fch1", 0.0)
+    foff = header.get("foff", 0.0)
+    freq_temp = fch1 + np.arange(nchans) * foff
+    if foff < 0:
+        config.DATA_NEEDS_REVERSAL = True
+        freq_temp = freq_temp[::-1]
+    else:
+        config.DATA_NEEDS_REVERSAL = False
+
+    config.FREQ = freq_temp
+    config.FREQ_RESO = nchans
+    config.TIME_RESO = tsamp
+    config.FILE_LENG = nsamples
+
+    if config.FREQ_RESO >= 512:
+        config.DOWN_FREQ_RATE = max(1, int(round(config.FREQ_RESO / 512)))
+    else:
+        config.DOWN_FREQ_RATE = 1
+    if config.TIME_RESO > 1e-9:
+        config.DOWN_TIME_RATE = max(1, int((49.152 * 16 / 1e6) / config.TIME_RESO))
+    else:
+        config.DOWN_TIME_RATE = 15

--- a/DRAFTS/pipeline.py
+++ b/DRAFTS/pipeline.py
@@ -26,6 +26,7 @@ from .image_utils import (
     plot_waterfall_block,
 )
 from .io import get_obparams, load_fits_file
+from .filterbank_io import load_fil_file, get_obparams_fil
 from .visualization import (
     save_plot,
     save_patch_plot,
@@ -59,9 +60,11 @@ def _load_class_model() -> torch.nn.Module:
     model.eval()
     return model
 
-def _find_fits_files(frb: str) -> List[Path]:
-    """Return FITS files matching ``frb`` within ``config.DATA_DIR``."""
-    return sorted(f for f in config.DATA_DIR.glob("*.fits") if frb in f.name)
+def _find_data_files(frb: str) -> List[Path]:
+    """Return FITS or filterbank files matching ``frb`` within ``config.DATA_DIR``."""
+
+    files = list(config.DATA_DIR.glob("*.fits")) + list(config.DATA_DIR.glob("*.fil"))
+    return sorted(f for f in files if frb in f.name)
 
 
 def _ensure_csv_header(csv_path: Path) -> None:
@@ -191,7 +194,10 @@ def _process_file(
     logger.info("Procesando %s", fits_path.name)
 
     try:
-        data = load_fits_file(str(fits_path))
+        if fits_path.suffix.lower() == ".fits":
+            data = load_fits_file(str(fits_path))
+        else:
+            data = load_fil_file(str(fits_path))
     except ValueError as e:
         if "corrupto" in str(e).lower():
             logger.error("Archivo corrupto detectado: %s - SALTANDO", fits_path.name)
@@ -445,12 +451,16 @@ def run_pipeline() -> None:
 
     summary: dict[str, dict] = {}
     for frb in config.FRB_TARGETS:
-        file_list = _find_fits_files(frb)
+        file_list = _find_data_files(frb)
         if not file_list:
             continue
 
         try:
-            get_obparams(str(file_list[0]))
+            first_file = file_list[0]
+            if first_file.suffix.lower() == ".fits":
+                get_obparams(str(first_file))
+            else:
+                get_obparams_fil(str(first_file))
         except Exception as e:
             logger.error("Error obteniendo parámetros de observación: %s", e)
             continue

--- a/tests/test_pipeline_utils.py
+++ b/tests/test_pipeline_utils.py
@@ -6,3 +6,16 @@ def test_slice_parameters():
     assert _slice_parameters(0, 512) == (0, 0)
     assert _slice_parameters(100, 512) == (100, 1)
     assert _slice_parameters(1024, 512) == (512, 2)
+from pathlib import Path
+from DRAFTS import config
+from DRAFTS.pipeline import _find_data_files
+
+def test_find_data_files(tmp_path):
+    (tmp_path / "A_test.fits").touch()
+    (tmp_path / "A_test.fil").touch()
+    config.DATA_DIR = tmp_path
+    files = _find_data_files("A_test")
+    assert len(files) == 2
+    assert any(f.suffix == ".fits" for f in files)
+    assert any(f.suffix == ".fil" for f in files)
+


### PR DESCRIPTION
## Summary
- implement filterbank_io module to load `.fil` files
- extend pipeline to handle `.fil` and `.fits` seamlessly
- search for either file type in data directory
- add tests for new file discovery logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68659c92a4808322861a93df17a10292