### PR TITLE
Add filterbank support to pipeline

### DIFF
--- a/DRAFTS/filterbank_io.py
+++ b/DRAFTS/filterbank_io.py
@@ -1,0 +1,144 @@
+"""Helper functions to read SIGPROC filterbank (.fil) files."""
+from __future__ import annotations
+
+import os
+import struct
+from pathlib import Path
+from typing import Tuple
+
+import numpy as np
+
+from . import config
+
+
+def _read_int(f) -> int:
+    return struct.unpack("<i", f.read(4))[0]
+
+
+def _read_double(f) -> float:
+    return struct.unpack("<d", f.read(8))[0]
+
+
+def _read_string(f) -> str:
+    length = _read_int(f)
+    return f.read(length).decode()
+
+
+def _read_header(f) -> Tuple[dict, int]:
+    start = _read_string(f)
+    if start != "HEADER_START":
+        raise ValueError("Invalid filterbank file")
+
+    header = {}
+    while True:
+        key = _read_string(f)
+        if key == "HEADER_END":
+            break
+        if key in {"rawdatafile", "source_name"}:
+            header[key] = _read_string(f)
+        elif key in {
+            "telescope_id",
+            "machine_id",
+            "data_type",
+            "barycentric",
+            "pulsarcentric",
+            "nbits",
+            "nchans",
+            "nifs",
+            "nbeams",
+            "ibeam",
+            "nsamples",
+        }:
+            header[key] = _read_int(f)
+        elif key in {
+            "az_start",
+            "za_start",
+            "src_raj",
+            "src_dej",
+            "tstart",
+            "tsamp",
+            "fch1",
+            "foff",
+            "refdm",
+        }:
+            header[key] = _read_double(f)
+        else:
+            # Read unknown field as integer by default
+            header[key] = _read_int(f)
+    return header, f.tell()
+
+
+def load_fil_file(file_name: str) -> np.ndarray:
+    """Load a filterbank file and return data as ``(time, pol, channel)``."""
+    with open(file_name, "rb") as f:
+        header, hdr_len = _read_header(f)
+
+    nchans = header.get("nchans", 0)
+    nifs = header.get("nifs", 1)
+    nbits = header.get("nbits", 8)
+    nsamples = header.get("nsamples")
+    if nsamples is None:
+        bytes_per_sample = nifs * nchans * (nbits // 8)
+        file_size = os.path.getsize(file_name) - hdr_len
+        nsamples = file_size // bytes_per_sample
+
+    dtype = np.uint8
+    if nbits == 16:
+        dtype = np.int16
+    elif nbits == 32:
+        dtype = np.float32
+    elif nbits == 64:
+        dtype = np.float64
+
+    # Memory-map the data to avoid loading the entire file into memory
+    data = np.memmap(
+        file_name,
+        dtype=dtype,
+        mode="r",
+        offset=hdr_len,
+        shape=(nsamples, nifs, nchans),
+    )
+
+    if config.DATA_NEEDS_REVERSAL:
+        data = np.ascontiguousarray(data[:, :, ::-1])
+
+    return data
+
+
+def get_obparams_fil(file_name: str) -> None:
+    """Populate :mod:`config` using parameters from a filterbank file."""
+    with open(file_name, "rb") as f:
+        header, hdr_len = _read_header(f)
+
+    nchans = header.get("nchans", 0)
+    tsamp = header.get("tsamp", 0.0)
+    nifs = header.get("nifs", 1)
+    nbits = header.get("nbits", 8)
+    nsamples = header.get("nsamples")
+    if nsamples is None:
+        bytes_per_sample = nifs * nchans * (nbits // 8)
+        file_size = os.path.getsize(file_name) - hdr_len
+        nsamples = file_size // bytes_per_sample
+
+    fch1 = header.get("fch1", 0.0)
+    foff = header.get("foff", 0.0)
+    freq_temp = fch1 + np.arange(nchans) * foff
+    if foff < 0:
+        config.DATA_NEEDS_REVERSAL = True
+        freq_temp = freq_temp[::-1]
+    else:
+        config.DATA_NEEDS_REVERSAL = False
+
+    config.FREQ = freq_temp
+    config.FREQ_RESO = nchans
+    config.TIME_RESO = tsamp
+    config.FILE_LENG = nsamples
+
+    if config.FREQ_RESO >= 512:
+        config.DOWN_FREQ_RATE = max(1, int(round(config.FREQ_RESO / 512)))
+    else:
+        config.DOWN_FREQ_RATE = 1
+    if config.TIME_RESO > 1e-9:
+        config.DOWN_TIME_RATE = max(1, int((49.152 * 16 / 1e6) / config.TIME_RESO))
+    else:
+        config.DOWN_TIME_RATE = 15

--- a/DRAFTS/preprocessing.py
+++ b/DRAFTS/preprocessing.py
@@ -9,19 +9,14 @@ def downsample_data(data: np.ndarray) -> np.ndarray:
     """Down-sample time-frequency data using :mod:`config` rates."""
     n_time = (data.shape[0] // config.DOWN_TIME_RATE) * config.DOWN_TIME_RATE
     n_freq = (data.shape[2] // config.DOWN_FREQ_RATE) * config.DOWN_FREQ_RATE
+    n_pol = data.shape[1]
     data = data[:n_time, :, :n_freq]
-    data = (
-        np.mean(
-            data.reshape(
-                n_time // config.DOWN_TIME_RATE,
-                config.DOWN_TIME_RATE,
-                2,
-                n_freq // config.DOWN_FREQ_RATE,
-                config.DOWN_FREQ_RATE,
-            ),
-            axis=(1, 4),
-        )
-        .mean(axis=1)
-        .astype(np.float32)
+    data = data.reshape(
+        n_time // config.DOWN_TIME_RATE,
+        config.DOWN_TIME_RATE,
+        n_pol,
+        n_freq // config.DOWN_FREQ_RATE,
+        config.DOWN_FREQ_RATE,
     )
+    data = data.mean(axis=(1, 4, 2)).astype(np.float32)
     return data

--- a/tests/test_pipeline_utils.py
+++ b/tests/test_pipeline_utils.py
@@ -6,3 +6,16 @@ def test_slice_parameters():
     assert _slice_parameters(0, 512) == (0, 0)
     assert _slice_parameters(100, 512) == (100, 1)
     assert _slice_parameters(1024, 512) == (512, 2)
+from pathlib import Path
+from DRAFTS import config
+from DRAFTS.pipeline import _find_data_files
+
+def test_find_data_files(tmp_path):
+    (tmp_path / "A_test.fits").touch()
+    (tmp_path / "A_test.fil").touch()
+    config.DATA_DIR = tmp_path
+    files = _find_data_files("A_test")
+    assert len(files) == 2
+    assert any(f.suffix == ".fits" for f in files)
+    assert any(f.suffix == ".fil" for f in files)
+


### PR DESCRIPTION
## Summary
- implement filterbank_io module to load `.fil` files
- extend pipeline to handle `.fil` and `.fits` seamlessly
- search for either file type in data directory
- add tests for new file discovery logic
- improve filterbank load path and downsampling

## Testing
- `pytest -q`