### PR TITLE
Refactor pipeline into modular utilities

### DIFF
--- a/DRAFTS/csv_utils.py
+++ b/DRAFTS/csv_utils.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import csv
+import time
+from pathlib import Path
+
+from .candidate import Candidate
+
+__all__ = ["ensure_csv_header", "write_candidate"]
+
+
+HEADER = [
+    "file",
+    "slice",
+    "band",
+    "prob",
+    "dm_pc_cm-3",
+    "t_sec_absolute",
+    "t_sample",
+    "x1",
+    "y1",
+    "x2",
+    "y2",
+    "snr_peak",
+    "class_prob",
+    "is_burst",
+    "patch_file",
+]
+
+
+def ensure_csv_header(csv_path: Path) -> None:
+    """Create ``csv_path`` with the standard candidate header if missing."""
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    if csv_path.exists():
+        return
+
+    with csv_path.open("w", newline="") as f_csv:
+        writer = csv.writer(f_csv)
+        writer.writerow(HEADER)
+
+
+def write_candidate(csv_file: Path, candidate: Candidate) -> None:
+    """Append ``candidate`` to ``csv_file``."""
+    try:
+        with csv_file.open("a", newline="") as f_csv:
+            writer = csv.writer(f_csv)
+            writer.writerow(candidate.to_row())
+    except PermissionError:
+        alt_csv = csv_file.with_suffix(f".{int(time.time())}.csv")
+        with alt_csv.open("a", newline="") as f_csv:
+            writer = csv.writer(f_csv)
+            writer.writerow(candidate.to_row())

--- a/DRAFTS/detection_utils.py
+++ b/DRAFTS/detection_utils.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Tuple, List
+
+import numpy as np
+import torch
+
+from . import config
+
+__all__ = [
+    "detect_candidates",
+    "prep_patch",
+    "classify_patch",
+]
+
+
+def detect_candidates(model: torch.nn.Module, img: np.ndarray) -> Tuple[List, List | None]:
+    """Run the detection network on ``img`` and return confidences and boxes."""
+    from ObjectDet.centernet_utils import get_res
+
+    with torch.no_grad():
+        hm, wh, offset = model(
+            torch.from_numpy(img).to(config.DEVICE).float().unsqueeze(0)
+        )
+    conf, boxes = get_res(hm, wh, offset, confidence=config.DET_PROB)
+
+    if boxes is None:
+        return [], None
+
+    if isinstance(conf, np.ndarray):
+        conf = conf.tolist()
+    if isinstance(boxes, np.ndarray):
+        boxes = boxes.tolist()
+
+    return conf, boxes
+
+
+def prep_patch(patch: np.ndarray) -> np.ndarray:
+    """Normalize ``patch`` before classification."""
+    patch = patch.copy()
+    patch += 1
+    patch /= np.mean(patch, axis=0)
+    vmin, vmax = np.nanpercentile(patch, [5, 95])
+    patch = np.clip(patch, vmin, vmax)
+    patch = (patch - patch.min()) / (patch.max() - patch.min())
+    return patch
+
+
+def classify_patch(model: torch.nn.Module, patch: np.ndarray) -> Tuple[float, np.ndarray]:
+    """Return probability from classifier for ``patch`` along with processed patch."""
+    proc = prep_patch(patch)
+    tensor = torch.from_numpy(proc[None, None, :, :]).float().to(config.DEVICE)
+    with torch.no_grad():
+        out = model(tensor)
+        prob = out.softmax(dim=1)[0, 1].item()
+    return prob, proc

--- a/DRAFTS/file_utils.py
+++ b/DRAFTS/file_utils.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List
+
+import numpy as np
+
+from . import config
+
+__all__ = [
+    "find_data_files",
+    "slice_parameters",
+    "load_fil_chunk",
+    "write_summary",
+]
+
+
+def find_data_files(frb: str) -> List[Path]:
+    """Return FITS or filterbank files matching ``frb`` in ``config.DATA_DIR``."""
+    files = list(config.DATA_DIR.glob("*.fits")) + list(config.DATA_DIR.glob("*.fil"))
+    return sorted(f for f in files if frb in f.name)
+
+
+def slice_parameters(width_total: int, slice_len: int) -> tuple[int, int]:
+    """Return adjusted ``slice_len`` and number of slices."""
+    if width_total == 0:
+        return 0, 0
+    if width_total < slice_len:
+        return width_total, 1
+    return slice_len, width_total // slice_len
+
+
+def load_fil_chunk(file_path: str, start_sample: int, chunk_size: int) -> np.ndarray:
+    """Load a specific chunk from a filterbank file."""
+    from .filterbank_io import _read_header
+
+    with open(file_path, "rb") as f:
+        header, hdr_len = _read_header(f)
+
+    nchans = header["nchans"]
+    nbits = header["nbits"]
+    nifs = header.get("nifs", 1)
+    bytes_per_sample = nifs * nchans * (nbits // 8)
+
+    data_start_offset = hdr_len + start_sample * bytes_per_sample
+    bytes_to_read = chunk_size * bytes_per_sample
+
+    dtype = np.uint8
+    if nbits == 16:
+        dtype = np.int16
+    elif nbits == 32:
+        dtype = np.float32
+    elif nbits == 64:
+        dtype = np.float64
+
+    with open(file_path, "rb") as f:
+        f.seek(data_start_offset)
+        raw_data = f.read(bytes_to_read)
+
+    data_flat = np.frombuffer(raw_data, dtype=dtype)
+
+    if len(data_flat) == chunk_size * nchans * nifs:
+        data = data_flat.reshape(chunk_size, nifs, nchans)
+    else:
+        available = len(data_flat) // (nchans * nifs)
+        data = data_flat[: available * nchans * nifs].reshape(available, nifs, nchans)
+
+    if getattr(config, "DATA_NEEDS_REVERSAL", False):
+        data = data[:, :, ::-1]
+    return data
+
+
+def write_summary(summary: dict, save_path: Path) -> None:
+    """Write global summary information to ``summary.json``."""
+    summary_path = save_path / "summary.json"
+    with summary_path.open("w") as f_json:
+        json.dump(summary, f_json, indent=2)
+

--- a/DRAFTS/models.py
+++ b/DRAFTS/models.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import torch
+
+from . import config
+
+__all__ = [
+    "load_detection_model",
+    "load_classification_model",
+]
+
+
+def load_detection_model() -> torch.nn.Module:
+    """Load the CenterNet detection model."""
+    from ObjectDet.centernet_model import centernet
+
+    model = centernet(model_name=config.MODEL_NAME).to(config.DEVICE)
+    state = torch.load(config.MODEL_PATH, map_location=config.DEVICE)
+    model.load_state_dict(state)
+    model.eval()
+    return model
+
+
+def load_classification_model() -> torch.nn.Module:
+    """Load the binary classification model."""
+    from BinaryClass.binary_model import BinaryNet
+
+    model = BinaryNet(config.CLASS_MODEL_NAME, num_classes=2).to(config.DEVICE)
+    state = torch.load(config.CLASS_MODEL_PATH, map_location=config.DEVICE)
+    model.load_state_dict(state)
+    model.eval()
+    return model

--- a/DRAFTS/rfi_utils.py
+++ b/DRAFTS/rfi_utils.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+
+import numpy as np
+
+from . import config
+from .rfi_mitigation import RFIMitigator
+
+__all__ = ["apply_rfi_cleaning"]
+
+
+def apply_rfi_cleaning(
+    waterfall: np.ndarray,
+    stokes_v: np.ndarray | None = None,
+    output_dir: Path | None = None,
+) -> Tuple[np.ndarray, dict]:
+    """Apply RFI mitigation to ``waterfall`` if enabled."""
+    if not getattr(config, "RFI_ENABLE_ALL_FILTERS", False):
+        return waterfall, {}
+
+    rfi_mitigator = RFIMitigator(
+        freq_sigma_thresh=getattr(config, "RFI_FREQ_SIGMA_THRESH", 5.0),
+        time_sigma_thresh=getattr(config, "RFI_TIME_SIGMA_THRESH", 5.0),
+        zero_dm_sigma_thresh=getattr(config, "RFI_ZERO_DM_SIGMA_THRESH", 4.0),
+        impulse_sigma_thresh=getattr(config, "RFI_IMPULSE_SIGMA_THRESH", 6.0),
+        polarization_thresh=getattr(config, "RFI_POLARIZATION_THRESH", 0.8),
+    )
+
+    cleaned, stats = rfi_mitigator.clean_waterfall(
+        waterfall, stokes_v=stokes_v, apply_all_filters=True
+    )
+
+    if (
+        getattr(config, "RFI_SAVE_DIAGNOSTICS", False)
+        and output_dir
+        and stats.get("total_flagged_fraction", 0) > 0.001
+    ):
+        rfi_dir = output_dir / "rfi_diagnostics"
+        rfi_dir.mkdir(parents=True, exist_ok=True)
+        diagnostic_path = rfi_dir / "rfi_cleaning_diagnostics.png"
+        rfi_mitigator.plot_rfi_diagnostics(waterfall, cleaned, diagnostic_path)
+
+    return cleaned, stats


### PR DESCRIPTION
## Summary
- refactor pipeline helpers into modular utilities
- delegate RFI cleaning, model loading, detection and CSV handling to new modules
- keep existing API by importing helpers in pipeline

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687183d38ac083229e28940951202bb0